### PR TITLE
Makefile updated: new targets, -f on clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,18 @@
 CFLAGS=-Wall
+prefix:=/usr/local
 
 hyt-read: hyt-read.c
 	$(CC) $(CFLAGS) -o $@ $^
 
+.PHONY: install
+install: hyt-read
+	mkdir -p $(prefix)/sbin
+	install -m 0755 -t $(prefix)/sbin $^
+
+.PHONY: uninstall
+uninstall:
+	rm -f $(prefix)/sbin/hyt-read
+
 .PHONY: clean
 clean:
-	rm hyt-read
+	rm -f hyt-read


### PR DESCRIPTION
"rm" without "-f" fails when the binary is missing, so "clean & compile" button fails on Netbeans (and maybe on other IDEs)
Added "install" and "uninstall" targets: the i2c bus cannot be read by normal users, so the binary should be installed in */sbin (default: /usr/local/sbin)
